### PR TITLE
Polish layout and remove theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
         <li><a href="#certifications">Certifications</a></li>
         <li><a href="#resume">Resume</a></li>
         <li><a href="#contact">Contact</a></li>
-        <li><button id="theme-toggle">🌙</button></li>
       </ul>
     </nav>
   </div>
@@ -116,10 +115,10 @@
 
 <section id="resume">
   <h2>Resume</h2>
-  <a href="images/Rob_Burns_Resume.pdf" download class="btn">Download Resume</a>
+  <a href="images/Rob_Burns_Resume.pdf" download class="btn download-btn">Download Resume</a>
   <div class="grid">
     <div class="card">
-      <embed src="images/Rob_Burns_Resume.pdf" type="application/pdf" width="100%" height="300px" />
+      <iframe src="images/Rob_Burns_Resume.pdf" class="pdf-viewer"></iframe>
     </div>
   </div>
 </section>

--- a/style.css
+++ b/style.css
@@ -94,12 +94,6 @@ nav a, .logo {
   font-weight: bold;
 }
 
-#theme-toggle {
-  background: none;
-  border: none;
-  color: white;
-  cursor: pointer;
-}
 
 .hero {
   display: flex;
@@ -115,8 +109,8 @@ nav a, .logo {
   font-size: 4rem;
 }
 
-.hero .btn {
-  margin-top: 1rem;
+.btn {
+  display: inline-block;
   padding: 0.75rem 1.5rem;
   background: #4f46e5;
   color: white;
@@ -124,6 +118,18 @@ nav a, .logo {
   border-radius: 6px;
   font-weight: bold;
   cursor: pointer;
+  text-decoration: none;
+}
+
+.hero .btn {
+  margin-top: 1.25rem;
+}
+
+.hero-right p {
+  font-size: 1.25rem;
+  font-weight: 600;
+  border-left: 3px solid #8b5cf6;
+  padding-left: 1rem;
 }
 
 section {
@@ -132,12 +138,24 @@ section {
   padding: 4rem 2rem;
 }
 
+section h2 {
+  margin-bottom: 1.25rem;
+}
+
 .about {
   display: flex;
   gap: 2rem;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
+}
+.about-left {
+  flex: 2;
+}
+
+.about-right {
+  flex: 1;
+  text-align: center;
 }
 
 .about-right img {
@@ -224,6 +242,22 @@ button[type="submit"] {
   border-radius: 6px;
   font-weight: bold;
   cursor: pointer;
+}
+
+.pdf-viewer {
+  width: 100%;
+  height: 500px;
+  border: 2px solid #4f46e5;
+  border-radius: 8px;
+}
+
+#resume .btn {
+  margin-bottom: 1rem;
+}
+
+.download-btn {
+  background: #1a1a2e;
+  border: 2px solid #4f46e5;
 }
 
 footer {


### PR DESCRIPTION
## Summary
- remove unused dark mode toggle
- refine hero area styles and tagline
- ensure about section aligns left with headshot to the right
- add global button styles and improved resume layout
- tweak spacing between section titles and content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684130f5cb4c832b87766bebfd0b7987