### PR TITLE
Adjust resume styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,6 @@
   <h2>Projects</h2>
   <div class="grid">
     <div class="card">
-      <img src="images/task-manager.png" alt="Task Manager App" />
       <div class="overlay">
         <p>A sleek to-do list app with user authentication and database storage.</p>
         <a href="#" class="btn">Website</a>
@@ -64,7 +63,6 @@
       <h4>Task Manager App</h4>
     </div>
     <div class="card">
-      <img src="images/movie-watchlist.png" alt="Movie Watchlist App" />
       <div class="overlay">
         <p>Search and track your favorite movies with a responsive React frontend.</p>
         <a href="#" class="btn">Website</a>

--- a/style.css
+++ b/style.css
@@ -92,6 +92,11 @@ nav a, .logo {
   color: white;
   text-decoration: none;
   font-weight: bold;
+  transition: color 0.3s;
+}
+
+nav a:hover {
+  color: #8b5cf6;
 }
 
 
@@ -184,6 +189,10 @@ section h2 {
   transform: scale(1.03);
 }
 
+#resume .card:hover {
+  transform: none;
+}
+
 .card img {
   width: 100%;
   border-radius: 6px;
@@ -253,7 +262,7 @@ button[type="submit"] {
 .pdf-viewer {
   width: 100%;
   height: 500px;
-  border: 2px solid #4f46e5;
+  border: none;
   border-radius: 8px;
 }
 
@@ -264,6 +273,7 @@ button[type="submit"] {
 .download-btn {
   background: #1a1a2e;
   border: 2px solid #4f46e5;
+  margin-top: 0.5rem;
 }
 
 footer {
@@ -338,6 +348,9 @@ footer {
   .hero h1 {
     font-size: 2.5rem;
   }
+  .header-container {
+    position: relative;
+  }
   nav {
     position: relative;
   }
@@ -358,6 +371,7 @@ footer {
     cursor: pointer;
     font-size: 1.5rem;
     color: white;
+    margin-left: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak project card layout to remove screenshots
- remove border from pdf viewer and disable card hover
- space resume download button lower
- add color change on nav link hover
- push hamburger menu to the far right on mobile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684134c11998832badb48574ea508662