### PR TITLE
Add Easter egg thank-you message under Certifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,14 @@
 
 <section id="certifications">
   <h2>Certifications</h2>
+  <p id="cert-thank-you" class="thank-you">
+    A special thank you to VetBoss and ERA Solutions.
+    Your support and guidance gave me the opportunity to learn how to code and
+    earn these amazing certifications — a path that has genuinely changed my
+    life. This experience has sparked a deep passion for web development, and
+    I’m incredibly grateful for the doors it has opened. Thank you for investing
+    in my future.
+  </p>
   <div class="grid">
     <div class="card"><img src="images/htmlcss_cert.png" alt="HTML & CSS" /><h4>HTML & CSS</h4></div>
     <div class="card"><img src="images/javascript_cert.png" alt="JavaScript" /><h4>JavaScript</h4></div>

--- a/script.js
+++ b/script.js
@@ -21,6 +21,15 @@ document.addEventListener('DOMContentLoaded', () => {
     modal.classList.remove('show');
   });
 
+  // Easter egg thank-you message
+  const certTitle = document.querySelector('#certifications h2');
+  const thanksMsg = document.getElementById('cert-thank-you');
+  if (certTitle && thanksMsg) {
+    certTitle.addEventListener('click', () => {
+      thanksMsg.classList.toggle('visible');
+    });
+  }
+
   // Scroll to top button
   const scrollBtn = document.getElementById('scrollTop');
   window.addEventListener('scroll', () => {

--- a/style.css
+++ b/style.css
@@ -248,6 +248,19 @@ section h2 {
   text-align: center;
 }
 
+.thank-you {
+  display: none;
+  max-width: 800px;
+  margin: 0 auto 1rem;
+  line-height: 1.6;
+  color: #ddd;
+  font-size: 1rem;
+}
+
+.thank-you.visible {
+  display: block;
+}
+
 .placeholder {
   text-align: center;
   padding: 4rem;


### PR DESCRIPTION
## Summary
- add a hidden thank-you note under the Certifications header
- style the message and hide it by default
- toggle the thank-you note on click of the Certifications title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68413dda23cc832b91512df9747a7409